### PR TITLE
fix(loader): propagate plugin asset version digest to scoped stylesheet (closes #23 #24)

### DIFF
--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -11,7 +11,16 @@ if (typeof document !== 'undefined') {
     const link = document.createElement('link')
     link.id = id
     link.rel = 'stylesheet'
-    link.href = new URL(/* @vite-ignore */ './index.css', import.meta.url).href
+    // Carry over the `?v=<digest>` cache-busting query the host puts on the JS
+    // bundle URL (see app-ui plugins/loader.js): relative URL resolution drops
+    // the base query, so without this the stylesheet stays unversioned while
+    // the JS rotates its digest on every plugin upgrade. The scoped-style
+    // `data-v-*` ids then mismatch between a freshly-loaded JS bundle and a
+    // cached index.css, silently breaking every SFC layout in this plugin.
+    const cssUrl = new URL(/* @vite-ignore */ './index.css', import.meta.url)
+    const selfQuery = new URL(import.meta.url).search
+    if (selfQuery) cssUrl.search = selfQuery
+    link.href = cssUrl.href
     document.head.appendChild(link)
   }
 }


### PR DESCRIPTION
## Problem

The host loader (`app-ui/.../plugins/loader.js`) imports the plugin JS bundle via `/main/<id>/vue/index.js?v=<digest>`, where the MD5 digest rotates on every plugin upgrade (long-cached for 1 year, immutable). However, the CSS injection inside `ui/src/index.js` did:

```js
link.href = new URL('./index.css', import.meta.url).href
```

Relative URL resolution drops the base query string, so the `<link>` pointed at `index.css` **without** the `?v=` cache buster. As a consequence, after any plugin upgrade the freshly-loaded JS bundle (new `data-v-*` scope id) was paired with a stale, long-cached `index.css` (previous `data-v-*` ids). Every scoped style of the SFCs in this plugin silently stopped matching, producing apparently random layout regressions with zero JS errors.

## Fix

Carry over the `?v=<digest>` query from `import.meta.url` to the CSS URL so the stylesheet is busted in lockstep with the JS bundle. Bonus: the CSS now benefits from the same 1-year immutable cache as the JS in production.

## Closes

- closes #23 (Admin stat-bar layout broken on all system views)
- closes #24 (Cache view: success rate column displayed as ×100)

Both were manifestations of the same root cause: scoped CSS classes silently dropped after each plugin upgrade.

## Verified

- Runtime test before/after the fix: stat-bar layout restored on Plugins / Nodes / Configuration / Cache views; success-rate column in Cache view now displays correct percentages (94%, 71%, 79%) instead of absurd values (5980%, 3091%, etc.).